### PR TITLE
Added temporary fix for Greasemonkey on Firefox

### DIFF
--- a/HD_Helper_unstable.js
+++ b/HD_Helper_unstable.js
@@ -221,10 +221,8 @@ function searchIPdat() {
     $.getScript("https://legacy.hackerexperience.com/js/main.js.pagespeed.jm.oC0Po-3w4s.js", function() {});
 }
 
-if (document.getElementsByClassName("link active")[0].innerText == "IP List\n") {
-    injectTab();
-    injectSettingsDiv();
-}
+injectTab();
+injectSettingsDiv();
 
 function isEven(n) {
     return n % 2 === 0;


### PR DESCRIPTION
Seems like this line:

``` javascript
document.getElementById("loadAll").addEventListener("click", loadAll);
```

Was returning some kind of getElementById is null error.
