### PR TITLE
More elegant way to fix the Firefox issue

### DIFF
--- a/HD_Helper_unstable.js
+++ b/HD_Helper_unstable.js
@@ -221,8 +221,10 @@ function searchIPdat() {
     $.getScript("https://legacy.hackerexperience.com/js/main.js.pagespeed.jm.oC0Po-3w4s.js", function() {});
 }
 
-injectTab();
-injectSettingsDiv();
+if (document.getElementsByClassName("link active")[0].innerText == "IP List") {
+    injectTab();
+    injectSettingsDiv();
+}
 
 function isEven(n) {
     return n % 2 === 0;


### PR DESCRIPTION
If you run the following line in the Console in Firefox:

``` javascript
document.getElementsByClassName("link active")[0].innerText
```

You see that there is no \n behind the IP List.
