### PR TITLE
Fixing an issue I created before

### DIFF
--- a/HD_Helper_unstable.js
+++ b/HD_Helper_unstable.js
@@ -221,7 +221,7 @@ function searchIPdat() {
     $.getScript("https://legacy.hackerexperience.com/js/main.js.pagespeed.jm.oC0Po-3w4s.js", function() {});
 }
 
-if (document.getElementsByClassName("link active")[0].innerText == "IP List") {
+if (document.getElementsByClassName("link active")[0].innerText == "IP List" || document.getElementsByClassName("link active")[0].innerText == "IP List\n") {
     injectTab();
     injectSettingsDiv();
 }


### PR DESCRIPTION
The fix I created a pull request for for Firefox turned out to break for Chrome. The output of

``` javascript
document.getElementsByClassName("link active")[0].innerText
```

Is different for Chrome and Firefox. Chrome outputs `IP List\n` while Firefox outputs `IP List`. This pull request checks if either one of these two appear. Tested on Chrome and Firefox.
